### PR TITLE
Use lcd over cd.

### DIFF
--- a/autoload/fzfproject/autoroot.vim
+++ b/autoload/fzfproject/autoroot.vim
@@ -2,7 +2,7 @@ function! fzfproject#autoroot#switchroot()
   if getbufinfo('%')[0]['listed'] && filereadable(@%)
     let l:root = fnamemodify(FugitiveGitDir(), ":h")
     if isdirectory(l:root)
-      execute 'cd ' . l:root
+      execute 'lcd ' . l:root
     endif
   endif
 endfunction


### PR DESCRIPTION
The `cd` command will change the directory for every window the user has open.

By using `lcd`, the directory is changed for the current window only. 

(see `help lcd`)