### PR TITLE
fix tmp path for windows, and add /d option in cd for windows to support folder in other than c drive

### DIFF
--- a/autoload/fzfproject.vim
+++ b/autoload/fzfproject.vim
@@ -57,8 +57,9 @@ function! s:setFileToSwitchTo(lines)
 endfunction
 
 function! fzfproject#switch()
+  let l:is_win = has('win32') || has('win64')
   let l:opts = {
-    \ 'dir': '/tmp',
+    \ 'dir': l:is_win ? $TEMP : '/tmp',
     \ 'sink': function('s:switchToProjectDir'),
     \ 'source': s:formatProjectList(s:projectList),
     \ 'down': '40%'

--- a/autoload/fzfproject/find.vim
+++ b/autoload/fzfproject/find.vim
@@ -37,9 +37,9 @@ function! fzfproject#find#file(root_first, dir)
   endif
 
   let l:dir = a:dir == -1 ? getcwd() : a:dir
-
-  let l:opts = { 
-        \ 'dir': '/tmp',
+  let l:is_win = has('win32') || has('win64')
+  let l:opts = {
+        \ 'dir': l:is_win ? $TEMP : '/tmp',
         \ 'sink*' : function('s:switchToFile', [l:dir]),
         \ 'down': '40%',
         \ 'options': [
@@ -51,8 +51,7 @@ function! fzfproject#find#file(root_first, dir)
         \ }
 
   if FugitiveIsGitDir(getcwd() . '/.git') 
-    let l:is_win = has('win32') || has('win64')
-    let l:opts['source'] = 'cd ' .. l:dir .. ' && ' .. s:listFilesCommand . (l:is_win ? '' : ' | uniq')
+    let l:opts['source'] = 'cd ' . (l:is_win ? '/d' : '') .. l:dir .. ' && ' .. s:listFilesCommand . (l:is_win ? '' : ' | uniq')
   endif
 
   return fzf#run(fzf#wrap(l:opts))


### PR DESCRIPTION
@benwainwright Please review this PR to support recent change on windows. Basically on windows there was errors because /tmp path does not exist. Have also added /d option in cd command so that it will work on windows if path is not in c drive.